### PR TITLE
feat: enhance Pix2Text initialization with total_configs support 

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+# Update 2026.02.07: **V1.1.6** Released
+
+Major Changes:
+
+- The `Pix2Text` class now supports config-based initialization directly via `__init__`, with the same parameters as `from_config()`. Users can now use `Pix2Text(total_configs=..., enable_table=True, device='cuda')` instead of `Pix2Text.from_config(...)`.
+
+主要变更：
+
+- `Pix2Text` 类现在支持通过 `__init__` 直接进行基于配置的初始化，参数与 `from_config()` 相同。用户现在可以使用 `Pix2Text(total_configs=..., enable_table=True, device='cuda')` 代替 `Pix2Text.from_config(...)`。
+
 # Update 2026.02.07: **V1.1.5** Released
 
 Major Changes:

--- a/pix2text/__version__.py
+++ b/pix2text/__version__.py
@@ -2,4 +2,4 @@
 # [Pix2Text](https://github.com/breezedeus/pix2text): an Open-Source Alternative to Mathpix.
 # Copyright (C) 2022-2025, [Breezedeus](https://www.breezedeus.com).
 
-__version__ = '1.1.5'
+__version__ = '1.1.6'

--- a/tests/test_pix2text.py
+++ b/tests/test_pix2text.py
@@ -227,3 +227,29 @@ def test_multilingual_ocr():
         img_fp, file_type="text_formula", return_text=True, auto_line_break=False
     )
     print(outs)
+
+
+def test_init_with_total_configs():
+    """Test that Pix2Text can be initialized with total_configs directly (same as from_config)."""
+    total_config = {
+        'layout': {},
+        'text_formula': {
+            'formula': {
+                'model_name': 'mfr-1.5',
+                'model_backend': 'onnx',
+                'more_model_configs': {'provider': 'CPUExecutionProvider'},
+            }
+        },
+    }
+    # Initialize using total_configs parameter directly
+    p2t = Pix2Text(total_configs=total_config, enable_table=False, device='cpu')
+
+    assert p2t.layout_parser is not None
+    assert p2t.text_formula_ocr is not None
+    assert p2t.table_ocr is None  # enable_table=False
+    assert p2t.enable_formula is True  # default value
+    img_fp = './docs/examples/page2.png'
+    outs = p2t.recognize(
+        img_fp, file_type="text_formula", return_text=True, auto_line_break=False
+    )
+    print(outs)


### PR DESCRIPTION
# Update 2026.02.07: **V1.1.6** Released

Major Changes:

- The `Pix2Text` class now supports config-based initialization directly via `__init__`, with the same parameters as `from_config()`. Users can now use `Pix2Text(total_configs=..., enable_table=True, device='cuda')` instead of `Pix2Text.from_config(...)`.

主要变更：

- `Pix2Text` 类现在支持通过 `__init__` 直接进行基于配置的初始化，参数与 `from_config()` 相同。用户现在可以使用 `Pix2Text(total_configs=..., enable_table=True, device='cuda')` 代替 `Pix2Text.from_config(...)`。