### PR TITLE
Add MiniMax VLM endpoint support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -133,6 +133,33 @@ p2t = Pix2Text(total_configs=total_config)
 ```
 `model_name` 和 `api_key` 的取值，具体可参考 [LiteLLM 文档](https://docs.litellm.ai/docs/)。
 
+MiniMax-M3 can be configured through the OpenAI-compatible LiteLLM adapter:
+
+```python
+import os
+from pix2text import Pix2Text
+
+vlm_config = {
+    "model_name": "openai/MiniMax-M3",
+    "api_key": os.getenv("MINIMAX_API_KEY"),
+    "api_base": os.getenv("MINIMAX_API_BASE", "https://api.minimax.io/v1"),
+}
+total_config = {
+    "layout": None,
+    "text_formula": {
+        "model_type": "VlmTextFormulaOCR",
+        **vlm_config,
+    },
+    "table": {
+        "model_type": "VlmTableOCR",
+        **vlm_config,
+    },
+}
+p2t = Pix2Text.from_config(total_configs=total_config)
+```
+
+Set `MINIMAX_API_BASE=https://api.minimaxi.com/v1` to use the China endpoint.
+
 ### 方法二：使用 `from_config` 类方法
 
 也可以通过 `from_config` 类方法来初始化，功能与方法一完全相同：

--- a/pix2text/pix_to_text.py
+++ b/pix2text/pix_to_text.py
@@ -67,6 +67,7 @@ def prepare_text_formula_ocr_engine(
         text_formula_ocr = VlmTextFormulaOCR.from_config(
             model_name=text_formula_config["model_name"],
             api_key=text_formula_config["api_key"],
+            api_base=text_formula_config.get("api_base"),
             **kwargs,
         )
     else:
@@ -100,6 +101,7 @@ def prepare_table_ocr_engine(
         table_ocr = VlmTableOCR.from_config(
             model_name=table_config["model_name"],
             api_key=table_config["api_key"],
+            api_base=table_config.get("api_base"),
             **kwargs,
         )
     else:

--- a/pix2text/text_formula_ocr.py
+++ b/pix2text/text_formula_ocr.py
@@ -606,6 +606,7 @@ class VlmTextFormulaOCR(TextFormulaOCR):
             **kwargs (): Reserved for other parameters: 
                 * model_name (str): The name of the VLM model; defaults to `None`, which means using the default model.
                 * api_key (str): The API key for the VLM model; defaults to `None`, which means using the default API key.
+                * api_base (str): The base URL for an OpenAI-compatible API; defaults to `None`.
         """
         from .vlm_api import Vlm
 
@@ -618,6 +619,7 @@ class VlmTextFormulaOCR(TextFormulaOCR):
         vlm = Vlm(
             model_name=all_kwargs.pop("model_name", None),
             api_key=all_kwargs.pop("api_key", None),
+            api_base=all_kwargs.pop("api_base", None),
         )
 
         spellchecker = None

--- a/pix2text/vlm_api.py
+++ b/pix2text/vlm_api.py
@@ -146,9 +146,16 @@ class Vlm(object):
     This class uses the Litellm library to interact with the VLM API.
     """
 
-    def __init__(self, *, model_name: str, api_key: str) -> None:
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        api_key: str,
+        api_base: Optional[str] = None,
+    ) -> None:
         self.model_name = model_name
         self.api_key = api_key
+        self.api_base = api_base
 
     def __call__(
         self,
@@ -194,6 +201,8 @@ class Vlm(object):
             )
 
         try:
+            if self.api_base:
+                kwargs.setdefault("api_base", self.api_base)
             responses = batch_completion(
                 model=self.model_name,
                 messages=messages,

--- a/pix2text/vlm_table_ocr.py
+++ b/pix2text/vlm_table_ocr.py
@@ -86,6 +86,7 @@ class VlmTableOCR(object):
         vlm = Vlm(
             model_name=all_kwargs.pop("model_name", None),
             api_key=all_kwargs.pop("api_key", None),
+            api_base=all_kwargs.pop("api_base", None),
         )
 
         return cls(

--- a/tests/test_vlm_api_config.py
+++ b/tests/test_vlm_api_config.py
@@ -1,0 +1,47 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).parents[1] / "pix2text" / "vlm_api.py"
+SPEC = spec_from_file_location("vlm_api", MODULE_PATH)
+vlm_api = module_from_spec(SPEC)
+SPEC.loader.exec_module(vlm_api)
+
+
+def test_minimax_openai_compatible_endpoint(monkeypatch):
+    calls = []
+
+    def fake_batch_completion(**kwargs):
+        calls.append(kwargs)
+        return [
+            {
+                "choices": [
+                    {
+                        "message": {"content": "recognized text"},
+                        "logprobs": None,
+                    }
+                ]
+            }
+        ]
+
+    def fake_encode_image(*args, **kwargs):
+        return "image"
+
+    monkeypatch.setattr(vlm_api, "batch_completion", fake_batch_completion)
+    monkeypatch.setattr(vlm_api, "encode_image", fake_encode_image)
+
+    vlm = vlm_api.Vlm(
+        model_name="openai/MiniMax-M3",
+        api_key="test-key",
+        api_base="https://api.minimax.io/v1",
+    )
+
+    result = vlm("image.png", parsing_func=None)
+    assert result == {"text": "recognized text", "score": 0.0}
+    assert calls[-1]["api_base"] == "https://api.minimax.io/v1"
+
+    vlm(
+        "image.png",
+        parsing_func=None,
+        api_base="https://api.minimaxi.com/v1",
+    )
+    assert calls[-1]["api_base"] == "https://api.minimaxi.com/v1"


### PR DESCRIPTION
Reason: Pix2Text could not persist the MiniMax OpenAI-compatible endpoint in its VLM configuration, preventing MiniMax-M3 from being used for image OCR.

- Add constructor-level `api_base` support to the VLM wrapper.
- Forward the endpoint through text/formula and table OCR configuration.
- Document MiniMax-M3 setup for the global and China endpoints.
- Add mocked coverage for default and per-call endpoint selection.

Checks:
- `../../.octopatch-venv/bin/python -m pytest tests/test_vlm_api_config.py`
- `../../.octopatch-venv/bin/black --check tests/test_vlm_api_config.py`
- `../../.octopatch-venv/bin/flake8 tests/test_vlm_api_config.py`
- `../../.octopatch-venv/bin/python -m compileall -q pix2text/vlm_api.py pix2text/vlm_table_ocr.py pix2text/text_formula_ocr.py pix2text/pix_to_text.py tests/test_vlm_api_config.py`
- `git diff --check`
